### PR TITLE
add PATIENT, DOCTOR, PHARMACIST enums to Role

### DIFF
--- a/backend/src/main/java/com/cs490/group4/demo/config/MockDoctor.java
+++ b/backend/src/main/java/com/cs490/group4/demo/config/MockDoctor.java
@@ -23,7 +23,7 @@ public class MockDoctor {
             String specialty,
             Long licenseNumber) {
         Doctor doctor = new Doctor();
-        User user = mockUser.createMockUser(Role.USER, email, "password", firstName, lastName);
+        User user = mockUser.createMockUser(Role.DOCTOR, email, "password", firstName, lastName);
         doctor.setFirstName(firstName);
         doctor.setLastName(lastName);
         doctor.setEmail(email);

--- a/backend/src/main/java/com/cs490/group4/demo/config/MockPatient.java
+++ b/backend/src/main/java/com/cs490/group4/demo/config/MockPatient.java
@@ -23,7 +23,7 @@ public class MockPatient {
             String phone,
             String address) {
         Patient patient = new Patient();
-        User user = mockUser.createMockUser(Role.USER, email, "password", firstName, lastName);
+        User user = mockUser.createMockUser(Role.PATIENT, email, "password", firstName, lastName);
         patient.setEmail(email);
         patient.setFirstName(firstName);
         patient.setLastName(lastName);

--- a/backend/src/main/java/com/cs490/group4/demo/config/MockPharmacy.java
+++ b/backend/src/main/java/com/cs490/group4/demo/config/MockPharmacy.java
@@ -30,7 +30,7 @@ public class MockPharmacy {
         pharmacy.setName(name);
         pharmacy.setPhone(phone);
         pharmacy.setZipCode(zipCode);
-        User user = mockUser.createMockUser(Role.ADMIN, email, "password", "ADMIN", "ACCOUNT");
+        User user = mockUser.createMockUser(Role.PHARMACIST, email, "password", "ADMIN", "ACCOUNT");
         pharmacy.setUser(user);
         pharmacyRepository.save(pharmacy);
 

--- a/backend/src/main/java/com/cs490/group4/demo/controller/PatientController.java
+++ b/backend/src/main/java/com/cs490/group4/demo/controller/PatientController.java
@@ -1,6 +1,7 @@
 package com.cs490.group4.demo.controller;
 
 import com.cs490.group4.demo.service.DoctorService;
+import com.cs490.group4.demo.service.PatientService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,18 +10,18 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/doctors")
-public class DoctorController {
+@RequestMapping("/patients")
+public class PatientController {
 
     @Autowired
-    private DoctorService doctorService;
+    private PatientService patientService;
 
     @GetMapping()
-    private ResponseEntity<?> getDoctors(@RequestParam(required = false) Integer userId) {
+    private ResponseEntity<?> getPatients(@RequestParam(required = false) Integer userId) {
         if (userId != null) {
-            return ResponseEntity.ok(doctorService.getDoctorByUserId(userId));
+            return ResponseEntity.ok(patientService.getPatientByUserId(userId));
         } else {
-            return ResponseEntity.ok(doctorService.getAllDoctors());
+            return ResponseEntity.ok(patientService.getAllPatients());
         }
     }
 }

--- a/backend/src/main/java/com/cs490/group4/demo/dao/DoctorRepository.java
+++ b/backend/src/main/java/com/cs490/group4/demo/dao/DoctorRepository.java
@@ -1,7 +1,11 @@
 package com.cs490.group4.demo.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface DoctorRepository extends JpaRepository<Doctor, Integer> {
 
+    @Query("SELECT d FROM Doctor d JOIN d.user u where u.userId = :userId")
+    public Doctor findByUserId(@Param("userId") Integer userId);
 }

--- a/backend/src/main/java/com/cs490/group4/demo/dao/PatientRepository.java
+++ b/backend/src/main/java/com/cs490/group4/demo/dao/PatientRepository.java
@@ -1,7 +1,11 @@
 package com.cs490.group4.demo.dao;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PatientRepository extends JpaRepository<Patient, Integer> {
 
+    @Query("SELECT p FROM Patient p JOIN p.user u where u.userId = :userId")
+    public Patient findByUserId(@Param("userId") Integer userId);
 }

--- a/backend/src/main/java/com/cs490/group4/demo/dto/authentication/RegisterRequestDTO.java
+++ b/backend/src/main/java/com/cs490/group4/demo/dto/authentication/RegisterRequestDTO.java
@@ -1,5 +1,6 @@
 package com.cs490.group4.demo.dto.authentication;
 
+import com.cs490.group4.demo.security.Role;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -12,5 +13,6 @@ import lombok.NoArgsConstructor;
 public class RegisterRequestDTO {
 
     private String firstName, lastName, email, password;
+    private Role role;
 
 }

--- a/backend/src/main/java/com/cs490/group4/demo/security/Role.java
+++ b/backend/src/main/java/com/cs490/group4/demo/security/Role.java
@@ -4,11 +4,8 @@ public enum Role {
 
     PATIENT,
     DOCTOR,
-    PHARMACIST;
-
-    // left these in because authentication stuff relies on it
-//    USER,
-//    ADMIN
+    PHARMACIST,
+    ADMIN;
 
     public boolean isUser() {
         return this == PATIENT || this == DOCTOR;

--- a/backend/src/main/java/com/cs490/group4/demo/security/Role.java
+++ b/backend/src/main/java/com/cs490/group4/demo/security/Role.java
@@ -2,7 +2,16 @@ package com.cs490.group4.demo.security;
 
 public enum Role {
 
-    USER,
-    ADMIN
+    PATIENT,
+    DOCTOR,
+    PHARMACIST;
+
+    // left these in because authentication stuff relies on it
+//    USER,
+//    ADMIN
+
+    public boolean isUser() {
+        return this == PATIENT || this == DOCTOR;
+    }
 
 }

--- a/backend/src/main/java/com/cs490/group4/demo/security/config/JWTService.java
+++ b/backend/src/main/java/com/cs490/group4/demo/security/config/JWTService.java
@@ -50,7 +50,8 @@ public class JWTService {
         Map<String, String> tokens = new HashMap<>();
 
         String accessToken, refreshToken;
-        if (userDetails.getRole().equals(Role.ADMIN)) {
+//        if (userDetails.getRole().equals(Role.ADMIN)) {
+        if (userDetails.getRole().equals(Role.PHARMACIST)) {
             accessToken = Jwts.builder().setClaims(extraClaims).setSubject(userDetails.getUsername()).setIssuedAt(
                             new Date(System.currentTimeMillis())).setExpiration(new Date(System.currentTimeMillis() + ADMIN_ACCESS_TOKEN_EXPIRATION))
                     .signWith(getSigningKey(), SignatureAlgorithm.HS256).compact();

--- a/backend/src/main/java/com/cs490/group4/demo/service/DoctorService.java
+++ b/backend/src/main/java/com/cs490/group4/demo/service/DoctorService.java
@@ -13,6 +13,10 @@ public class DoctorService {
     @Autowired
     private DoctorRepository doctorRepository;
 
+    public Doctor getDoctorByUserId(Integer userId) {
+        return doctorRepository.findByUserId(userId);
+    }
+
     public List<Doctor> getAllDoctors() {
         return doctorRepository.findAll();
     }

--- a/backend/src/main/java/com/cs490/group4/demo/service/PatientService.java
+++ b/backend/src/main/java/com/cs490/group4/demo/service/PatientService.java
@@ -13,6 +13,10 @@ public class PatientService {
     @Autowired
     private PatientRepository patientRepository;
 
+    public Patient getPatientByUserId(Integer userId) {
+        return patientRepository.findByUserId(userId);
+    }
+
     public List<Patient> getAllPatients() {
         return patientRepository.findAll();
     }

--- a/backend/src/main/java/com/cs490/group4/demo/service/authentication/AuthenticationService.java
+++ b/backend/src/main/java/com/cs490/group4/demo/service/authentication/AuthenticationService.java
@@ -41,7 +41,8 @@ public class AuthenticationService {
                 .lastName(request.getLastName())
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
-                .role(Role.USER).build();
+                .role(request.getRole()).build();
+//                .role(Role.USER).build();
         if (repository.findByEmail(user.getEmail()).isEmpty()) {
             User savedUser = repository.save(user);
             /*
@@ -61,7 +62,7 @@ public class AuthenticationService {
     public AuthenticationResponseDTO authenticate(AuthenticationRequestDTO request) throws Exception {
         try {
             authenticationManager.authenticate(new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
-        } catch(Exception e){
+        } catch (Exception e) {
             throw new Exception("Account not found");
         }
         // user successfully authenticated, so generate a token and send it back to the client

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import {createBrowserRouter, RouterProvider} from 'react-router-dom'
 import "@fontsource/roboto/300.css";
 import "@fontsource/roboto/400.css";
 import "@fontsource/roboto/500.css";
@@ -11,45 +11,50 @@ import SignInPage from './pages/SignInPage.jsx';
 import SignupPage from './pages/SignupPage.jsx';
 import PatientDashboard from './pages/Patient/PatientDashboard.jsx';
 import DoctorDashboard from "./pages/Doctor/DoctorDashboard.jsx";
+import {QueryClient, QueryClientProvider} from "@tanstack/react-query";
 
+
+const queryClient = new QueryClient()
 const router = createBrowserRouter([
-  {
-    path: '/',
-    element:
-      <Auth notRequired>
-        <LandingPage />
-      </Auth>
-  },
-  {
-    path: '/signin',
-    element:
-      <Auth>
-        <SignInPage />
-      </Auth>
-  },
-  {
-    path: '/signup',
-    element:
-      <Auth notRequired>
-        <SignupPage />
-      </Auth>
-  },
-  {
-    path: '/patient/dashboard',
-    element:
-      <Auth>
-        <PatientDashboard />
-      </Auth>
-  },
-  {
-    path: '/doctor/dashboard',
-    element:
-        <Auth>
-          <DoctorDashboard/>
-        </Auth>
-  }
+    {
+        path: '/',
+        element:
+            <Auth notRequired>
+                <LandingPage/>
+            </Auth>
+    },
+    {
+        path: '/signin',
+        element:
+            <Auth>
+                <SignInPage/>
+            </Auth>
+    },
+    {
+        path: '/signup',
+        element:
+            <Auth notRequired>
+                <SignupPage/>
+            </Auth>
+    },
+    {
+        path: '/patient/dashboard',
+        element:
+            <Auth>
+                <PatientDashboard/>
+            </Auth>
+    },
+    {
+        path: '/doctor/dashboard',
+        element:
+            <Auth>
+                <DoctorDashboard/>
+            </Auth>
+    }
 ])
 
 ReactDOM.createRoot(document.getElementById('root')).render(
-  <RouterProvider router={router} />
+    <QueryClientProvider client={queryClient}>
+        <RouterProvider router={router}/>
+    </QueryClientProvider>
 )


### PR DESCRIPTION
Removed USER and ADMIN
Depending on role in the user (from useEffect in Auth), it fetches the role-specific data accordingly.

Right now there are two seperate states in Auth for authentication data (users table), and application data (patient | doctor | pharmacy) table, could we instead merge these into one dto? :o

Added role to registration dto